### PR TITLE
Allow deterministic behavior with `ran_init`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -66,6 +66,7 @@ fn main() {
         .allowlist_function("breakcellwt")
         .allowlist_function("settolist")
         .allowlist_function("listtoset")
+        .allowlist_function("ran_init")
         .allowlist_var("dispatch_graph")
         .allowlist_var("dispatch_sparse")
         // types are off for the following


### PR DESCRIPTION
Allows deterministic behavior by calling `ran_init(0)` before a `sparsenauty` or `Traces` call. Without this, returned generator lists can be non-deterministic according to the documentation, and I confirmed this for `Traces`.

I plan to publish a crate that critically depends on this change in a month or so. I'd appreciate it if you pushed this change into a new version until then. Thanks, @a-maier!