### PR TITLE
Add equivalents to nauty's defaults for directed graphs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -69,6 +69,8 @@ fn main() {
         .allowlist_function("ran_init")
         .allowlist_function("ran_init_time")
         .allowlist_function("ran_nextran")
+        .allowlist_function("adjacencies")
+        .allowlist_function("adjacencies_sg")
         .allowlist_var("dispatch_graph")
         .allowlist_var("dispatch_sparse")
         // types are off for the following

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub fn SETWORDSNEEDED(n: usize) -> usize {
 }
 
 impl std::default::Default for optionblk {
+    /// Default options for undirected graphs, equivalent to nauty's DEFAULTOPTIONS_GRAPH.
     fn default() -> Self {
         optionblk {
             getcanon: 0,
@@ -67,34 +68,36 @@ impl std::default::Default for optionblk {
 }
 
 impl optionblk {
+    /// Default options for directed graphs, equivalent to nauty's DEFAULTOPTIONS_DIGRAPH.
+    pub fn default_digraph() -> Self {
+        optionblk {
+            digraph: TRUE,
+            invarproc: Some(adjacencies),
+            maxinvarlevel: 999,
+            ..Self::default()
+        }
+    }
+
+    /// Default options for undirected sparse graphs, equivalent to nauty's DEFAULTOPTIONS_SPARSEGRAPH.
     pub fn default_sparse() -> Self {
         optionblk {
-            getcanon: 0,
-            digraph: FALSE,
-            writeautoms: FALSE,
-            writemarkers: FALSE,
-            defaultptn: TRUE,
-            cartesian: FALSE,
-            linelength: CONSOLWIDTH,
-            outfile: std::ptr::null_mut(),
-            userrefproc: None,
-            userautomproc: None,
-            userlevelproc: None,
-            usernodeproc: None,
-            usercanonproc: None,
-            invarproc: None,
-            tc_level: 100,
-            mininvarlevel: 0,
-            maxinvarlevel: 1,
-            invararg: 0,
             dispatch: unsafe { &mut dispatch_sparse },
-            schreier: FALSE,
-            extra_options: std::ptr::null_mut(),
+            ..Self::default()
+        }
+    }
+
+    /// Default options for directed sparse graphs, equivalent to nauty's DEFAULTOPTIONS_SPARSEDIGRAPH.
+    pub fn default_sparse_digraph() -> Self {
+        optionblk {
+            invarproc: Some(adjacencies_sg),
+            dispatch: unsafe { &mut dispatch_sparse },
+            ..Self::default_digraph()
         }
     }
 }
 
 impl std::default::Default for TracesOptions {
+    /// Default options for undirected graphs, equivalent to Traces' DEFAULTOPTIONS_TRACES.
     fn default() -> Self {
         TracesOptions {
             getcanon: FALSE,

--- a/wrapper-bundled.h
+++ b/wrapper-bundled.h
@@ -1,5 +1,6 @@
 #include "src/nauty2_8_6/nauty.h"
 #include "src/nauty2_8_6/naugroup.h"
 #include "src/nauty2_8_6/nausparse.h"
+#include "src/nauty2_8_6/nautinv.h"
 #include "src/nauty2_8_6/traces.h"
 #include "src/nauty2_8_6/gutils.h"

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,5 +1,6 @@
 #include <nauty/nauty.h>
 #include <nauty/naugroup.h>
 #include <nauty/nausparse.h>
+#include <nauty/nautinv.h>
 #include <nauty/traces.h>
 #include <nauty/gutils.h>


### PR DESCRIPTION
Adds the equivalent of DEFAULTOPTIONS_SPARSEDIGRAPH that is recommended by nauty's API guide for directed sparse graphs (where it led to a speedup by a factor of 1000000 for me in some cases).

I also tried to add the equivalent of DEFAULTOPTIONS_DIGRAPH, but for some reason the 'adjacencies' function from nautinv.h is not found even when added to the allowlist. Perhaps you see why?